### PR TITLE
Ensure full model names

### DIFF
--- a/.changes/apparatus-bubble-direction-drug.json
+++ b/.changes/apparatus-bubble-direction-drug.json
@@ -1,0 +1,1 @@
+{"type":"MINOR","changes":["Ensure model names are always prefixed with 'models/'"]}

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -61,13 +61,7 @@ internal constructor(
     apiKey: String,
     generationConfig: GenerationConfig? = null,
     safetySettings: List<SafetySetting>? = null,
-  ) : this(
-    modelName,
-    apiKey,
-    generationConfig,
-    safetySettings,
-    APIController(apiKey, fullModelName(modelName))
-  )
+  ) : this(modelName, apiKey, generationConfig, safetySettings, APIController(apiKey, modelName))
 
   /**
    * Generates a response from the backend with the provided [Content]s.
@@ -188,11 +182,3 @@ internal constructor(
       ?.let { throw ResponseStoppedException(this) }
   }
 }
-
-/**
- * Ensures the model name provided has a `models/` prefix
- *
- * Models must be prepended with the `models/` prefix when communicating with the backend.
- */
-private fun fullModelName(name: String): String =
-  name.takeIf { it.startsWith("models/") } ?: "models/$name"

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -61,7 +61,13 @@ internal constructor(
     apiKey: String,
     generationConfig: GenerationConfig? = null,
     safetySettings: List<SafetySetting>? = null,
-  ) : this(modelName, apiKey, generationConfig, safetySettings, APIController(apiKey, modelName))
+  ) : this(
+    modelName,
+    apiKey,
+    generationConfig,
+    safetySettings,
+    APIController(apiKey, fullModelName(modelName))
+  )
 
   /**
    * Generates a response from the backend with the provided [Content]s.
@@ -182,3 +188,11 @@ internal constructor(
       ?.let { throw ResponseStoppedException(this) }
   }
 }
+
+/**
+ * Ensures the model name provided has a `models/` prefix
+ *
+ * Models must be prepended with the `models/` prefix when communicating with the backend.
+ */
+private fun fullModelName(name: String): String =
+  name.takeIf { it.startsWith("models/") } ?: "models/$name"

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/internal/api/APIController.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/internal/api/APIController.kt
@@ -44,7 +44,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
 // TODO: Should these stay here or be moved elsewhere?
-internal const val DOMAIN = "https://generativelanguage.googleapis.com/v1/models"
+internal const val DOMAIN = "https://generativelanguage.googleapis.com/v1"
 
 internal val JSON = Json {
   ignoreUnknownKeys = true

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/internal/api/APIController.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/internal/api/APIController.kt
@@ -63,9 +63,11 @@ internal val JSON = Json {
  */
 internal class APIController(
   private val key: String,
-  private val model: String,
+  model: String,
   httpEngine: HttpClientEngine = OkHttp.create()
 ) {
+  private val model = fullModelName(model)
+
   private val client =
     HttpClient(httpEngine) {
       install(HttpTimeout) {
@@ -105,6 +107,14 @@ internal class APIController(
     header("x-goog-api-client", "genai-android/${BuildConfig.VERSION_NAME}")
   }
 }
+
+/**
+ * Ensures the model name provided has a `models/` prefix
+ *
+ * Models must be prepended with the `models/` prefix when communicating with the backend.
+ */
+private fun fullModelName(name: String): String =
+  name.takeIf { it.startsWith("models/") } ?: "models/$name"
 
 /**
  * Makes a POST request to the specified [url] and returns a [Flow] of deserialized response objects


### PR DESCRIPTION
Per [b/316424853](https://b.corp.google.com/issues/316424853),

This ensures model names are always prefixed with "models/", since the backend expects that format.