### PR TITLE
Add Proguard rule

### DIFF
--- a/.changes/butto-crime-bait-bucket.json
+++ b/.changes/butto-crime-bait-bucket.json
@@ -1,0 +1,1 @@
+{"type":"MINOR","changes":["Update proguard rules to not obfuscate serialization types"]}

--- a/generativeai/consumer-rules.pro
+++ b/generativeai/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.google.ai.client.generativeai.internal.** { *; }

--- a/generativeai/proguard-rules.pro
+++ b/generativeai/proguard-rules.pro
@@ -19,4 +19,3 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
--keep class com.google.ai.client.generativeai.internal.** { *; }

--- a/generativeai/proguard-rules.pro
+++ b/generativeai/proguard-rules.pro
@@ -19,3 +19,4 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keep class com.google.ai.client.generativeai.internal.** { *; }


### PR DESCRIPTION
Excludes internal serialization types from Proguard minification, preventing crashes for minified apps.