### PR TITLE
fix(proguard): keep enum members classes

### DIFF
--- a/.changes/carpenter-aunt-change-cat.json
+++ b/.changes/carpenter-aunt-change-cat.json
@@ -1,0 +1,1 @@
+{"type":"MINOR","changes":["Update proguard rules to not obfuscate enum types"]}

--- a/generativeai/consumer-rules.pro
+++ b/generativeai/consumer-rules.pro
@@ -1,1 +1,3 @@
 -keep class com.google.ai.client.generativeai.internal.** { *; }
+-keepclassmembers enum com.google.ai.client.generativeai.internal** { *; }
+


### PR DESCRIPTION
## Summary
This PR addresses issue #29, which caused consumer apps to crash when using the library in release mode.

### Issue Details

Without this rule you get this when the consumer app has Proguard/R8 minification enabled:
```
Caused by: java.lang.NoSuchFieldException: UNKNOWN
  at java.lang.Class.getField(Class.java:2337)
  at com.google.ai.client.generativeai.internal.util.FirstOrdinalSerializer.deserialize(SourceFile:2)
  at com.google.ai.client.generativeai.internal.api.server.FinishReasonSerializer.deserialize
``` 