### PR TITLE
Fix Kotlin version leakage

### DIFF
--- a/.changes/cook-boat-ball-board.json
+++ b/.changes/cook-boat-ball-board.json
@@ -1,0 +1,1 @@
+{"type":"MAJOR","changes":["Prevent Kotlin version from leaking 1.9.0 instead of 1.8.22"]}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,10 +16,10 @@
 
 plugins {
     id("com.android.library") version "8.1.3" apply false
-    id("org.jetbrains.dokka") version "1.9.10" apply false
+    id("org.jetbrains.dokka") version "1.8.20" apply false
     kotlin("android") version "1.8.22" apply false
-    kotlin("plugin.serialization") version "1.9.0" apply false
-    id("com.ncorti.ktfmt.gradle") version "0.15.1" apply false
+    kotlin("plugin.serialization") version "1.8.22" apply false
+    id("com.ncorti.ktfmt.gradle") version "0.16.0" apply false
     id("license-plugin")
 }
 

--- a/generativeai/build.gradle.kts
+++ b/generativeai/build.gradle.kts
@@ -72,13 +72,15 @@ android {
 }
 
 dependencies {
-    implementation("io.ktor:ktor-client-okhttp:2.3.5")
-    implementation("io.ktor:ktor-client-core:2.3.5")
-    implementation("io.ktor:ktor-client-content-negotiation:2.3.5")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.5")
-    implementation("io.ktor:ktor-client-logging:2.3.5")
+    val ktorVersion = "2.3.2"
 
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+    implementation("io.ktor:ktor-client-okhttp:$ktorVersion")
+    implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+    implementation("io.ktor:ktor-client-logging:$ktorVersion")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("org.slf4j:slf4j-android:1.7.36")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
@@ -88,15 +90,14 @@ dependencies {
     implementation("com.google.guava:listenablefuture:1.0")
     implementation("androidx.concurrent:concurrent-futures:1.2.0-alpha02")
     implementation("androidx.concurrent:concurrent-futures-ktx:1.2.0-alpha02")
-
     testImplementation("junit:junit:4.13.2")
     testImplementation("io.kotest:kotest-assertions-core:4.0.7")
     testImplementation("io.kotest:kotest-assertions-jvm:4.0.7")
-    testImplementation("io.ktor:ktor-client-mock:2.3.5")
+    testImplementation("io.ktor:ktor-client-mock:$ktorVersion")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 
-    dokkaPlugin("org.jetbrains.dokka:android-documentation-plugin:1.9.10")
+    dokkaPlugin("org.jetbrains.dokka:android-documentation-plugin:1.8.20")
 }
 
 publishing {

--- a/plugins/build.gradle.kts
+++ b/plugins/build.gradle.kts
@@ -19,9 +19,9 @@ plugins {
     `java-gradle-plugin`
     `kotlin-dsl`
     kotlin("jvm") version "1.8.22"
-    id("com.ncorti.ktfmt.gradle") version "0.15.1"
+    id("com.ncorti.ktfmt.gradle") version "0.16.0"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
-    kotlin("plugin.serialization") version "1.9.0"
+    kotlin("plugin.serialization") version "1.8.22"
 }
 
 ktfmt {


### PR DESCRIPTION
Per [b/318687943](https://b.corp.google.com/issues/318687943),

This fixes an issue where we were leaking `1.9.0` instead of the intended `1.8.22` version of Kotlin.

More specifically, we upgrade our `ktfmt` to rectify a bug that was present and causing the kotlin version to clash with other plugins. We also downgrade our `ktor`, `dokka`, and `serialization` plugins/dependencies to ensure they aren't leaking `1.9.x` anywhere.