### PR TITLE
Fix FindChangesTask not finding the latest api file

### DIFF
--- a/plugins/src/main/java/com/google/gradle/plugins/ApiPlugin.kt
+++ b/plugins/src/main/java/com/google/gradle/plugins/ApiPlugin.kt
@@ -69,7 +69,7 @@ abstract class ApiPlugin : Plugin<Project> {
 
   context(Project)
   private fun ApiPluginExtension.commonConfiguration() {
-    val latestApiFile = project.file("api/${project.version}.api")
+    val latestApiFile = rootProject.file("api/${project.version}.api")
 
     apiFile.convention(latestApiFile)
   }


### PR DESCRIPTION
Per [b/322982573](https://b.corp.google.com/issues/322982573),

This fixes the issue with `findChanges` not working correctly. The issue stemmed from the fact that it was still looking for the current `.api` file in the project directory- when we've migrated to a `api` directory at the root.