### PR TITLE
Implement RequestOptions

### DIFF
--- a/.changes/behavior-attention-channel-bottle.json
+++ b/.changes/behavior-attention-channel-bottle.json
@@ -1,0 +1,1 @@
+{"type":"MINOR","changes":["Add RequestOptions; configuration points for backend implementation details such as api version and timeout."]}

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -29,6 +29,7 @@ import com.google.ai.client.generativeai.type.GenerateContentResponse
 import com.google.ai.client.generativeai.type.GenerationConfig
 import com.google.ai.client.generativeai.type.GoogleGenerativeAIException
 import com.google.ai.client.generativeai.type.PromptBlockedException
+import com.google.ai.client.generativeai.type.RequestOptions
 import com.google.ai.client.generativeai.type.ResponseStoppedException
 import com.google.ai.client.generativeai.type.SafetySetting
 import com.google.ai.client.generativeai.type.SerializationException
@@ -45,6 +46,7 @@ import kotlinx.coroutines.flow.map
  * @property generationConfig configuration parameters to use for content generation
  * @property safetySettings the safety bounds to use during alongside prompts during content
  *   generation
+ * @property requestOptions configuration options to utilize during backend communication
  */
 class GenerativeModel
 internal constructor(
@@ -52,6 +54,7 @@ internal constructor(
   val apiKey: String,
   val generationConfig: GenerationConfig? = null,
   val safetySettings: List<SafetySetting>? = null,
+  val requestOptions: RequestOptions = RequestOptions(),
   private val controller: APIController
 ) {
 
@@ -61,7 +64,8 @@ internal constructor(
     apiKey: String,
     generationConfig: GenerationConfig? = null,
     safetySettings: List<SafetySetting>? = null,
-  ) : this(modelName, apiKey, generationConfig, safetySettings, APIController(apiKey, modelName))
+    requestOptions: RequestOptions = RequestOptions(),
+  ) : this(modelName, apiKey, generationConfig, safetySettings, requestOptions, APIController(apiKey, modelName, requestOptions.apiVersion, requestOptions.timeout))
 
   /**
    * Generates a response from the backend with the provided [Content]s.

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -65,7 +65,14 @@ internal constructor(
     generationConfig: GenerationConfig? = null,
     safetySettings: List<SafetySetting>? = null,
     requestOptions: RequestOptions = RequestOptions(),
-  ) : this(modelName, apiKey, generationConfig, safetySettings, requestOptions, APIController(apiKey, modelName, requestOptions.apiVersion, requestOptions.timeout))
+  ) : this(
+    modelName,
+    apiKey,
+    generationConfig,
+    safetySettings,
+    requestOptions,
+    APIController(apiKey, modelName, requestOptions.apiVersion, requestOptions.timeout)
+  )
 
   /**
    * Generates a response from the backend with the provided [Content]s.

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/internal/api/APIController.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/internal/api/APIController.kt
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-
 @file:OptIn(FlowPreview::class)
 
 package com.google.ai.client.generativeai.internal.api
 
 import com.google.ai.client.generativeai.BuildConfig
 import com.google.ai.client.generativeai.internal.util.decodeToFlow
-import com.google.ai.client.generativeai.type.GoogleGenerativeAIException
 import com.google.ai.client.generativeai.type.ServerException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -41,6 +39,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
@@ -49,8 +48,6 @@ import kotlinx.coroutines.flow.timeout
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 internal const val DOMAIN = "https://generativelanguage.googleapis.com"
 
@@ -99,9 +96,13 @@ internal class APIController(
   }
 
   fun generateContentStream(request: GenerateContentRequest): Flow<GenerateContentResponse> {
-    return client.postStream<GenerateContentResponse>("$DOMAIN/$apiVersion/$model:streamGenerateContent?alt=sse") {
-      applyCommonConfiguration(request)
-    }.timeout(timeout)
+    return client
+      .postStream<GenerateContentResponse>(
+        "$DOMAIN/$apiVersion/$model:streamGenerateContent?alt=sse"
+      ) {
+        applyCommonConfiguration(request)
+      }
+      .timeout(timeout)
   }
 
   suspend fun countTokens(request: CountTokensRequest): CountTokensResponse {

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/Exceptions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/Exceptions.kt
@@ -18,6 +18,7 @@ package com.google.ai.client.generativeai.type
 
 import com.google.ai.client.generativeai.GenerativeModel
 import io.ktor.serialization.JsonConvertException
+import kotlinx.coroutines.TimeoutCancellationException
 
 /** Parent class for any errors that occur from [GenerativeModel]. */
 sealed class GoogleGenerativeAIException(message: String, cause: Throwable? = null) :
@@ -39,6 +40,8 @@ sealed class GoogleGenerativeAIException(message: String, cause: Throwable? = nu
             "Something went wrong while trying to deserialize a response from the server.",
             cause
           )
+        is TimeoutCancellationException ->
+          RequestTimeoutException("The request failed to complete in the allotted time.")
         else -> UnknownException("Something unexpected happened.", cause)
       }
   }
@@ -83,6 +86,14 @@ class ResponseStoppedException(val response: GenerateContentResponse, cause: Thr
     "Content generation stopped. Reason: ${response.candidates.first().finishReason?.name}",
     cause
   )
+
+/**
+ * A request took too long to complete.
+ *
+ * Usually occurs due to a user specified [timeout][RequestOptions.timeout].
+ */
+class RequestTimeoutException(message: String, cause: Throwable? = null) :
+  GoogleGenerativeAIException(message, cause)
 
 /** Catch all case for exceptions not explicitly expected. */
 class UnknownException(message: String, cause: Throwable? = null) :

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/RequestOptions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/RequestOptions.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.ai.client.generativeai.type
 
 import io.ktor.client.plugins.HttpTimeout

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/RequestOptions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/RequestOptions.kt
@@ -11,6 +11,6 @@ import kotlin.time.Duration.Companion.milliseconds
  * @property apiVersion the api endpoint to call.
  */
 class RequestOptions(
-    val timeout: Duration = HttpTimeout.INFINITE_TIMEOUT_MS.milliseconds,
-    val apiVersion: String = "v1"
+  val timeout: Duration = HttpTimeout.INFINITE_TIMEOUT_MS.milliseconds,
+  val apiVersion: String = "v1"
 )

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/RequestOptions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/RequestOptions.kt
@@ -1,0 +1,16 @@
+package com.google.ai.client.generativeai.type
+
+import io.ktor.client.plugins.HttpTimeout
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Configurable options unique to how requests to the backend are performed.
+ *
+ * @property timeout the maximum amount of time for a request to take, from start to finish.
+ * @property apiVersion the api endpoint to call.
+ */
+class RequestOptions(
+    val timeout: Duration = HttpTimeout.INFINITE_TIMEOUT_MS.milliseconds,
+    val apiVersion: String = "v1"
+)

--- a/generativeai/src/test/java/com/google/ai/client/generativeai/GenerativeModelTests.kt
+++ b/generativeai/src/test/java/com/google/ai/client/generativeai/GenerativeModelTests.kt
@@ -22,21 +22,13 @@ import com.google.ai.client.generativeai.util.commonTest
 import com.google.ai.client.generativeai.util.createResponses
 import com.google.ai.client.generativeai.util.prepareStreamingResponse
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.matchers.concurrent.shouldTimeout
 import io.kotest.matchers.shouldBe
 import io.ktor.utils.io.close
 import io.ktor.utils.io.writeFully
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Test
-import java.util.concurrent.TimeUnit
-import kotlin.coroutines.coroutineContext
-import kotlin.time.Duration
 
 internal class GenerativeModelTests {
   private val testTimeout = 5.seconds
@@ -58,11 +50,10 @@ internal class GenerativeModelTests {
   }
 
   @Test
-  fun `(generateContent) respects a custom timeout`() = commonTest(requestOptions = RequestOptions(2.seconds)) {
-    shouldThrow<RequestTimeoutException> {
-      withTimeout(testTimeout) {
-        model.generateContent("d")
+  fun `(generateContent) respects a custom timeout`() =
+    commonTest(requestOptions = RequestOptions(2.seconds)) {
+      shouldThrow<RequestTimeoutException> {
+        withTimeout(testTimeout) { model.generateContent("d") }
       }
     }
-  }
 }

--- a/generativeai/src/test/java/com/google/ai/client/generativeai/GenerativeModelTests.kt
+++ b/generativeai/src/test/java/com/google/ai/client/generativeai/GenerativeModelTests.kt
@@ -16,16 +16,27 @@
 
 package com.google.ai.client.generativeai
 
+import com.google.ai.client.generativeai.type.RequestOptions
+import com.google.ai.client.generativeai.type.RequestTimeoutException
 import com.google.ai.client.generativeai.util.commonTest
 import com.google.ai.client.generativeai.util.createResponses
 import com.google.ai.client.generativeai.util.prepareStreamingResponse
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.concurrent.shouldTimeout
 import io.kotest.matchers.shouldBe
 import io.ktor.utils.io.close
 import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Test
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
 
 internal class GenerativeModelTests {
   private val testTimeout = 5.seconds
@@ -42,6 +53,15 @@ internal class GenerativeModelTests {
       responses.collect {
         it.candidates.isEmpty() shouldBe false
         channel.close()
+      }
+    }
+  }
+
+  @Test
+  fun `(generateContent) respects a custom timeout`() = commonTest(requestOptions = RequestOptions(2.seconds)) {
+    shouldThrow<RequestTimeoutException> {
+      withTimeout(testTimeout) {
+        model.generateContent("d")
       }
     }
   }


### PR DESCRIPTION
Per [b/323174522](https://b.corp.google.com/issues/323174522),

This adds support for the new config point `RequestOptions`, with a timeout specification for requests. Requests will now timeout after the specified time. A test has also been implemented to verify this behavior.

This PR also fixes the following:

- [b/324075314](https://b.corp.google.com/issues/324075314) -> Add support for version selection in RequestOptions