### PR TITLE
Add `UnsupportedUserLocationException` for better error handling

### DIFF
--- a/generativeai/src/main/java/com/google/ai/client/generativeai/internal/api/APIController.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/internal/api/APIController.kt
@@ -19,6 +19,7 @@ package com.google.ai.client.generativeai.internal.api
 import com.google.ai.client.generativeai.BuildConfig
 import com.google.ai.client.generativeai.internal.util.decodeToFlow
 import com.google.ai.client.generativeai.type.ServerException
+import com.google.ai.client.generativeai.type.UnsupportedUserLocationException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngine
@@ -174,6 +175,10 @@ private suspend fun validateResponse(response: HttpResponse) {
         "Unexpected Response:\n$text"
       }
 
+    // TODO (b/325117891): Use a better method than string matching.
+    if (message == "User location is not supported for the API use.") {
+      throw UnsupportedUserLocationException()
+    }
     throw ServerException(message)
   }
 }

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/type/Exceptions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/type/Exceptions.kt
@@ -69,6 +69,16 @@ class PromptBlockedException(val response: GenerateContentResponse, cause: Throw
   )
 
 /**
+ * The user's location (region) is not supported by the API.
+ *
+ * See the Google documentation for a
+ * [list of regions](https://ai.google.dev/available_regions#available_regions) (countries and
+ * territories) where the API is available.
+ */
+class UnsupportedUserLocationException(cause: Throwable? = null) :
+  GoogleGenerativeAIException("User location is not supported for the API use.", cause)
+
+/**
  * Some form of state occurred that shouldn't have.
  *
  * Usually indicative of consumer error.

--- a/generativeai/src/test/java/com/google/ai/client/generativeai/UnarySnapshotTests.kt
+++ b/generativeai/src/test/java/com/google/ai/client/generativeai/UnarySnapshotTests.kt
@@ -23,6 +23,7 @@ import com.google.ai.client.generativeai.type.PromptBlockedException
 import com.google.ai.client.generativeai.type.ResponseStoppedException
 import com.google.ai.client.generativeai.type.SerializationException
 import com.google.ai.client.generativeai.type.ServerException
+import com.google.ai.client.generativeai.type.UnsupportedUserLocationException
 import com.google.ai.client.generativeai.util.goldenUnaryFile
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.should
@@ -92,6 +93,12 @@ internal class UnarySnapshotTests {
   fun `http error`() =
     goldenUnaryFile("failure-http-error.json", HttpStatusCode.PreconditionFailed) {
       withTimeout(testTimeout) { shouldThrow<ServerException> { model.generateContent() } }
+    }
+
+  @Test
+  fun `user location error`() =
+    goldenUnaryFile("failure-unsupported-user-location.json", HttpStatusCode.PreconditionFailed) {
+      withTimeout(testTimeout) { shouldThrow<UnsupportedUserLocationException> { model.generateContent() } }
     }
 
   @Test

--- a/generativeai/src/test/java/com/google/ai/client/generativeai/UnarySnapshotTests.kt
+++ b/generativeai/src/test/java/com/google/ai/client/generativeai/UnarySnapshotTests.kt
@@ -98,7 +98,9 @@ internal class UnarySnapshotTests {
   @Test
   fun `user location error`() =
     goldenUnaryFile("failure-unsupported-user-location.json", HttpStatusCode.PreconditionFailed) {
-      withTimeout(testTimeout) { shouldThrow<UnsupportedUserLocationException> { model.generateContent() } }
+      withTimeout(testTimeout) {
+        shouldThrow<UnsupportedUserLocationException> { model.generateContent() }
+      }
     }
 
   @Test

--- a/generativeai/src/test/resources/golden-files/unary/failure-unsupported-user-location.json
+++ b/generativeai/src/test/resources/golden-files/unary/failure-unsupported-user-location.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "code": 400,
+    "message": "User location is not supported for the API use.",
+    "status": "FAILED_PRECONDITION",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "[ORIGINAL ERROR] generic::failed_precondition: User location is not supported for the API use. [google.rpc.error_details_ext] { message: \"User location is not supported for the API use.\" }"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Instead of relying on the generic message to notify users that they are trying to access the API from an unsupported location, this PR adds an specific new exception that app developers can use.

Although the underlying mechanism is still string matching, abstracting this into the SDK rather than forcing every developer to do it on their own is still a win.