### PR TITLE
Support unreleased versioning

### DIFF
--- a/plugins/src/main/java/com/google/gradle/tasks/VersionBumpTask.kt
+++ b/plugins/src/main/java/com/google/gradle/tasks/VersionBumpTask.kt
@@ -49,6 +49,9 @@ abstract class VersionBumpTask : DefaultTask() {
 
   @TaskAction
   fun build() {
+    if(newVersion.get().major > 0)
+      throw RuntimeException("You're trying to bump the major version. This is a no 1.0+ zone!!")
+
     versionFile.get().rewriteLines {
       when {
         it.startsWith("version=") -> "version=${newVersion.get()}"

--- a/plugins/src/main/java/com/google/gradle/types/ModuleVersion.kt
+++ b/plugins/src/main/java/com/google/gradle/types/ModuleVersion.kt
@@ -223,11 +223,20 @@ data class ModuleVersion(
     version
       .let { it ?: if (pre != null) VersionType.PRE else VersionType.PATCH }
       .let {
-        when (it) {
+        when (it.adjustForUnreleased()) {
           VersionType.MAJOR -> copy(major = major + 1, minor = 0, patch = 0)
           VersionType.MINOR -> copy(minor = minor + 1, patch = 0)
           VersionType.PATCH -> copy(patch = patch + 1)
           VersionType.PRE -> copy(pre = pre?.bump())
         }
       }
+
+  /**
+   * Adjusts the [VersionType] to be at most a minor- if the current version is unreleased.
+   *
+   * Unreleased versions follow a convention of major = minor. So any major change needs to be
+   * adjusted to be a minor change- otherwise you risk releasing the project out of development.
+   */
+  private fun VersionType.adjustForUnreleased(): VersionType =
+    takeUnless { major == 0 } ?: coerceAtLeast(VersionType.MINOR)
 }


### PR DESCRIPTION
Per [b/325291331](https://b.corp.google.com/issues/325291331), 

This adds support for unreleased versioning to our version bump task. Since we're unreleased, and our major changes should actually be considered minor by semver standards, this change is important to ensure we don't accidentally release 1.0 before we're ready. To further enforce this, [b/325291417](https://b.corp.google.com/issues/325291417) has been added- in which an exception will be thrown if we try to release `1.0.0` or higher.