### PR TITLE
Pass the requestOptions object to APIController as is.

### DIFF
--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -71,7 +71,7 @@ internal constructor(
     generationConfig,
     safetySettings,
     requestOptions,
-    APIController(apiKey, modelName, requestOptions.apiVersion, requestOptions.timeout)
+    APIController(apiKey, modelName, requestOptions)
   )
 
   /**

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/internal/api/APIController.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/internal/api/APIController.kt
@@ -18,8 +18,8 @@ package com.google.ai.client.generativeai.internal.api
 
 import com.google.ai.client.generativeai.BuildConfig
 import com.google.ai.client.generativeai.internal.util.decodeToFlow
-import com.google.ai.client.generativeai.type.RequestOptions
 import com.google.ai.client.generativeai.type.InvalidAPIKeyException
+import com.google.ai.client.generativeai.type.RequestOptions
 import com.google.ai.client.generativeai.type.ServerException
 import com.google.ai.client.generativeai.type.UnsupportedUserLocationException
 import io.ktor.client.HttpClient

--- a/generativeai/src/test/java/com/google/ai/client/generativeai/util/tests.kt
+++ b/generativeai/src/test/java/com/google/ai/client/generativeai/util/tests.kt
@@ -121,14 +121,7 @@ internal fun createGenerativeModel(
   GenerativeModel(
     name,
     apikey,
-    controller =
-      APIController(
-        "super_cool_test_key",
-        name,
-        requestOptions.apiVersion,
-        requestOptions.timeout,
-        engine
-      )
+    controller = APIController("super_cool_test_key", name, requestOptions, engine)
   )
 
 /**


### PR DESCRIPTION
This will make code changes that add fields to the `requestOptions` object easier to do in the future.