### PR TITLE
Add support for FileData

### DIFF
--- a/.changes/crowd-birthday-drink-circle.json
+++ b/.changes/crowd-birthday-drink-circle.json
@@ -1,0 +1,1 @@
+{"type":"PATCH","changes":["Implement error catching for unsupported Part types."]}

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
@@ -85,6 +85,7 @@ object PartSerializer : JsonContentPolymorphicSerializer<Part>(Part::class) {
     return when {
       "text" in jsonObject -> TextPart.serializer()
       "inlineData" in jsonObject -> BlobPart.serializer()
+      "file_data" in jsonObject -> FileDataPart.serializer()
       else -> throw SerializationException("Unknown Part type")
     }
   }

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
@@ -52,6 +52,14 @@ data class Content(@EncodeDefault val role: String? = "user", val parts: List<Pa
 
 @Serializable data class BlobPart(@SerialName("inline_data") val inlineData: Blob) : Part
 
+
+@Serializable data class FileData(
+  @SerialName("mime_type")
+  val mimeType: String,
+  @SerialName("file_uri")
+  val fileUri: String
+)
+
 @Serializable
 data class Blob(
   @SerialName("mime_type") val mimeType: String,

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
@@ -54,11 +54,10 @@ data class Content(@EncodeDefault val role: String? = "user", val parts: List<Pa
 
 @Serializable data class FileDataPart(@SerialName("file_data") val fileData: FileData) : Part
 
-@Serializable data class FileData(
-  @SerialName("mime_type")
-  val mimeType: String,
-  @SerialName("file_uri")
-  val fileUri: String
+@Serializable
+data class FileData(
+  @SerialName("mime_type") val mimeType: String,
+  @SerialName("file_uri") val fileUri: String
 )
 
 @Serializable
@@ -84,7 +83,7 @@ object PartSerializer : JsonContentPolymorphicSerializer<Part>(Part::class) {
     val jsonObject = element.jsonObject
     return when {
       "text" in jsonObject -> TextPart.serializer()
-      "inlineData" in jsonObject -> BlobPart.serializer()
+      "inline_data" in jsonObject -> BlobPart.serializer()
       "file_data" in jsonObject -> FileDataPart.serializer()
       else -> throw SerializationException("Unknown Part type")
     }

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/shared/Types.kt
@@ -52,6 +52,7 @@ data class Content(@EncodeDefault val role: String? = "user", val parts: List<Pa
 
 @Serializable data class BlobPart(@SerialName("inline_data") val inlineData: Blob) : Part
 
+@Serializable data class FileDataPart(@SerialName("file_data") val fileData: FileData) : Part
 
 @Serializable data class FileData(
   @SerialName("mime_type")

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/internal/util/conversions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/internal/util/conversions.kt
@@ -126,6 +126,7 @@ internal fun Part.toPublic(): com.google.ai.client.generativeai.type.Part {
         com.google.ai.client.generativeai.type.BlobPart(inlineData.mimeType, data)
       }
     }
+    else -> throw SerializationException("Unsupported part type \"${javaClass.simpleName}\" provided. This model may not be supported by this SDK.")
   }
 }
 

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/internal/util/conversions.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/internal/util/conversions.kt
@@ -126,7 +126,10 @@ internal fun Part.toPublic(): com.google.ai.client.generativeai.type.Part {
         com.google.ai.client.generativeai.type.BlobPart(inlineData.mimeType, data)
       }
     }
-    else -> throw SerializationException("Unsupported part type \"${javaClass.simpleName}\" provided. This model may not be supported by this SDK.")
+    else ->
+      throw SerializationException(
+        "Unsupported part type \"${javaClass.simpleName}\" provided. This model may not be supported by this SDK."
+      )
   }
 }
 


### PR DESCRIPTION
Per [b/330773378](https://b.corp.google.com/issues/330773378),

This adds support for the new `FileData` part type for referencing storage files. This also adds "support" from the genai side, as a means of catching future api discrepancies between common and genai.