### PR TITLE
Depend on right mockk version

### DIFF
--- a/generativeai/build.gradle.kts
+++ b/generativeai/build.gradle.kts
@@ -87,7 +87,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("io.kotest:kotest-assertions-core:5.5.5")
     testImplementation("io.kotest:kotest-assertions-core-jvm:5.5.5")
-    testImplementation("io.mockk:mockk:1.13.10")
+    testImplementation("io.mockk:mockk:1.12.8")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 


### PR DESCRIPTION
Mockk 1.13.* depends on kotlin 1.9