### PR TITLE
Don't encode the model name in the outgoing request

### DIFF
--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/Request.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/Request.kt
@@ -36,4 +36,5 @@ data class GenerateContentRequest(
 ) : Request
 
 @Serializable
-data class CountTokensRequest(val model: String, val contents: List<Content>) : Request
+data class CountTokensRequest(@Transient val model: String? = null, val contents: List<Content>) :
+  Request

--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/Request.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/Request.kt
@@ -22,12 +22,13 @@ import com.google.ai.client.generativeai.common.shared.Content
 import com.google.ai.client.generativeai.common.shared.SafetySetting
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 sealed interface Request
 
 @Serializable
 data class GenerateContentRequest(
-  val model: String,
+  @Transient val model: String? = null,
   val contents: List<Content>,
   @SerialName("safety_settings") val safetySettings: List<SafetySetting>? = null,
   @SerialName("generation_config") val generationConfig: GenerationConfig? = null,


### PR DESCRIPTION
The field can be ignored in the request.

b/331762991