### PR TITLE
Add clientId parameter in common

### DIFF
--- a/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
+++ b/common/src/main/kotlin/com/google/ai/client/generativeai/common/APIController.kt
@@ -59,20 +59,23 @@ val JSON = Json {
  *   Exposed primarily for DI in tests.
  * @property key The API key used for authentication.
  * @property model The model to use for generation.
+ * @property clientId The value to pass in the `x-goog-api-client` header.
  */
 class APIController
 internal constructor(
   private val key: String,
   model: String,
   private val requestOptions: RequestOptions,
-  httpEngine: HttpClientEngine
+  httpEngine: HttpClientEngine,
+  private val clientId: String
 ) {
 
   constructor(
     key: String,
     model: String,
-    requestOptions: RequestOptions
-  ) : this(key, model, requestOptions, OkHttp.create())
+    requestOptions: RequestOptions,
+    clientId: String
+  ) : this(key, model, requestOptions, OkHttp.create(), clientId)
 
   private val model = fullModelName(model)
 
@@ -127,7 +130,7 @@ internal constructor(
     }
     contentType(ContentType.Application.Json)
     header("x-goog-api-key", key)
-    header("x-goog-api-client", "genai-android/${BuildConfig.VERSION_NAME}")
+    header("x-goog-api-client", clientId)
   }
 }
 

--- a/common/src/test/java/com/google/ai/client/generativeai/common/APIControllerTests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/APIControllerTests.kt
@@ -201,7 +201,7 @@ internal class RequestFormatTests {
 
     mockEngine.requestHistory.first().headers["x-goog-api-client"] shouldBe TEST_CLIENT_ID
   }
-  
+
   @Test
   fun `ToolConfig serialization contains correct keys`() = doBlocking {
     val channel = ByteChannel(autoFlush = true)
@@ -211,7 +211,13 @@ internal class RequestFormatTests {
     prepareStreamingResponse(createResponses("Random")).forEach { channel.writeFully(it) }
 
     val controller =
-      APIController("super_cool_test_key", "gemini-pro-1.0", RequestOptions(), mockEngine)
+      APIController(
+        "super_cool_test_key",
+        "gemini-pro-1.0",
+        RequestOptions(),
+        mockEngine,
+        TEST_CLIENT_ID
+      )
 
     withTimeout(5.seconds) {
       controller

--- a/common/src/test/java/com/google/ai/client/generativeai/common/util/tests.kt
+++ b/common/src/test/java/com/google/ai/client/generativeai/common/util/tests.kt
@@ -38,6 +38,8 @@ import java.io.File
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 
+private val TEST_CLIENT_ID = "genai-android/test"
+
 internal fun prepareStreamingResponse(response: List<GenerateContentResponse>): List<ByteArray> =
   response.map { "data: ${JSON.encodeToString(it)}$SSE_SEPARATOR".toByteArray() }
 
@@ -104,7 +106,8 @@ internal fun commonTest(
   val mockEngine = MockEngine {
     respond(channel, status, headersOf(HttpHeaders.ContentType, "application/json"))
   }
-  val apiController = APIController("super_cool_test_key", "gemini-pro", requestOptions, mockEngine)
+  val apiController =
+    APIController("super_cool_test_key", "gemini-pro", requestOptions, mockEngine, TEST_CLIENT_ID)
   CommonTestScope(channel, apiController).block()
 }
 

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -86,7 +86,12 @@ internal constructor(
     safetySettings,
     tools,
     requestOptions,
-    APIController(apiKey, modelName, requestOptions.toInternal(),  "genai-android/${BuildConfig.VERSION_NAME}"),
+    APIController(
+      apiKey,
+      modelName,
+      requestOptions.toInternal(),
+      "genai-android/${BuildConfig.VERSION_NAME}"
+    ),
   )
 
   /**

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -86,7 +86,7 @@ internal constructor(
     safetySettings,
     tools,
     requestOptions,
-    APIController(apiKey, modelName, requestOptions.toInternal()),
+    APIController(apiKey, modelName, requestOptions.toInternal(),  "genai-android/${BuildConfig.VERSION_NAME}"),
   )
 
   /**


### PR DESCRIPTION
This parameter is used to fill the `x-goog-api-client` header