### PR TITLE
keep GenerativeModel's original parameter positions

### DIFF
--- a/.changes/generativeai/beginner-car-club-airport.json
+++ b/.changes/generativeai/beginner-car-club-airport.json
@@ -1,0 +1,1 @@
+{"type":"MAJOR","changes":["Keep argument positions"]}

--- a/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
+++ b/generativeai/src/main/java/com/google/ai/client/generativeai/GenerativeModel.kt
@@ -79,9 +79,9 @@ internal constructor(
     apiKey: String,
     generationConfig: GenerationConfig? = null,
     safetySettings: List<SafetySetting>? = null,
+    requestOptions: RequestOptions = RequestOptions(),
     tools: List<Tool>? = null,
     toolConfig: ToolConfig? = null,
-    requestOptions: RequestOptions = RequestOptions(),
   ) : this(
     modelName,
     apiKey,


### PR DESCRIPTION
It seems like the `tools` and `toolConfig` parameters were added before `requestOptions`, which could cause a breaking change because in the current version of the SDK the `RequestOptions` is in a different order (right after `safetySettings`).